### PR TITLE
fix: update lowcode-engine version to latest

### DIFF
--- a/packages/demo-x6/public/index.html
+++ b/packages/demo-x6/public/index.html
@@ -52,7 +52,7 @@
   <script src="https://cdn.jsdelivr.net/npm/@antv/x6@1.31.0/dist/x6.js"></script>
   <!-- 低代码引擎的主包 -->
   <script crossorigin="anonymous"
-    src="https://alifd.alicdn.com/npm/@alilc/lowcode-engine@1.0.15-beta.2/dist/js/engine-core.js"></script>
+    src="https://alifd.alicdn.com/npm/@alilc/lowcode-engine@latest/dist/js/engine-core.js"></script>
   <script crossorigin="anonymous" src="//g.alicdn.com/ali-lowcode/vision-polyfill/2.0.8/index.js"></script>
   <!-- 低代码引擎官方扩展的主包 -->
   <script crossorigin="anonymous"


### PR DESCRIPTION
引擎版本为旧版本，会导致初始化物料库报错